### PR TITLE
Add override specifier for getAnalysisUsage.

### DIFF
--- a/include/llvm/Transforms/LoopTime/LoopTimer.h
+++ b/include/llvm/Transforms/LoopTime/LoopTimer.h
@@ -39,7 +39,7 @@ namespace {
         public:
             static char ID;
             CountLoops():LoopPass(ID){}
-            void getAnalysisUsage(AnalysisUsage&AU)const ;
+            void getAnalysisUsage(AnalysisUsage&AU) const override;
             bool runOnLoop(Loop *L,LPPassManager&) override;
         };
     }


### PR DESCRIPTION
This compiles with LLVM/Clang 4.0.1.